### PR TITLE
ウィンドウ別グループ化機能を実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,3 +31,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `chrome.tabs` と `chrome.tabGroups` APIが必要
 - サービスワーカーは永続的でないため、イベント駆動で動作
 - ドメイン抽出時にchrome://やchrome-extension://は除外
+- 機能を追加したり、修正するときは必ずブランチを分けてください
+  - 新機能: feature/hogehoge
+  - 修正: fix/fugafuga

--- a/popup.js
+++ b/popup.js
@@ -38,10 +38,12 @@ function showStatus(message) {
   statusElement.textContent = message;
 }
 
-// グループリストを更新
+// グループリストを更新（現在のウィンドウのみ）
 async function updateGroupList() {
   try {
-    const groups = await chrome.tabGroups.query({});
+    // 現在のウィンドウを取得
+    const currentWindow = await chrome.windows.getCurrent();
+    const groups = await chrome.tabGroups.query({ windowId: currentWindow.id });
     const groupList = document.getElementById('groupList');
     groupList.innerHTML = '';
     
@@ -84,13 +86,19 @@ function getColorCode(color) {
   return colorMap[color] || '#4285f4';
 }
 
-// タブをグループ化する関数
+// タブをグループ化する関数（現在のウィンドウのみ）
 async function groupTabs() {
   try {
     showStatus('タブをグループ化中...');
     
+    // 現在のウィンドウIDを取得
+    const currentWindow = await chrome.windows.getCurrent();
+    
     // バックグラウンドスクリプトにメッセージを送信
-    await chrome.runtime.sendMessage({ action: 'groupTabs' });
+    await chrome.runtime.sendMessage({ 
+      action: 'groupTabsInWindow', 
+      windowId: currentWindow.id 
+    });
     
     // 少し待ってからグループリストを更新
     setTimeout(() => {
@@ -103,12 +111,14 @@ async function groupTabs() {
   }
 }
 
-// すべてのグループを解除する関数
+// すべてのグループを解除する関数（現在のウィンドウのみ）
 async function ungroupAll() {
   try {
     showStatus('グループを解除中...');
     
-    const groups = await chrome.tabGroups.query({});
+    // 現在のウィンドウのグループのみを取得
+    const currentWindow = await chrome.windows.getCurrent();
+    const groups = await chrome.tabGroups.query({ windowId: currentWindow.id });
     
     for (const group of groups) {
       const tabs = await chrome.tabs.query({ groupId: group.id });


### PR DESCRIPTION
## 概要
複数ウィンドウ間でのタブグループ化処理を分離し、ウィンドウごとに独立したグループ管理を可能にしました。これにより、ユーザーは各ウィンドウで異なるグループ構成を保持できるようになります。

## 変更内容
### background.js
- **新関数追加**: `groupTabsByDomainInWindow(windowId)` - 特定ウィンドウ内でのグループ化処理
- **既存関数改修**: `groupTabsByDomain()` - 全ウィンドウを順次処理するように変更
- **ウィンドウ限定処理**: `regroupSingleTab()` - 同一ウィンドウ内のみでグループ処理
- **イベント最適化**: タブ作成・更新時は該当ウィンドウのみを処理
- **新メッセージハンドラー**: `groupTabsInWindow` アクション追加

### popup.js
- **ウィンドウ限定表示**: グループリストを現在のウィンドウのみに限定
- **手動グループ化改善**: 現在のウィンドウのみでグループ化実行
- **グループ解除改善**: 現在のウィンドウのグループのみを解除

## 影響範囲
- [x] Chrome拡張機能の動作
- [x] UI/UX
- [x] パフォーマンス
- [ ] 既存機能への影響

## テスト
- [x] 基本的な動作確認
- [x] 新機能の動作確認
- [x] 既存機能の動作確認
- [x] マルチウィンドウでの動作確認

## 主要な改善点
1. **独立性**: 各ウィンドウで独立したグループ管理
2. **パフォーマンス**: 不要な全ウィンドウ処理を削減
3. **ユーザビリティ**: ウィンドウごとの異なるグループ構成が可能
4. **効率性**: 関連するウィンドウのみを処理することで動作速度向上

## 使用シナリオ
- **作業用ウィンドウ**: 開発関連のタブをグループ化
- **個人用ウィンドウ**: SNSやエンタメ系タブをグループ化
- **調査用ウィンドウ**: リサーチ関連のタブをグループ化

各ウィンドウで独立したタブ管理が可能になり、より柔軟なワークフローをサポートします。

🤖 Generated with [Claude Code](https://claude.ai/code)