### PR TITLE
ポップアップのスクロール位置リセット問題を修正

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -46,6 +46,11 @@ async function updateGroupList() {
     const currentWindow = await chrome.windows.getCurrent();
     const groups = await chrome.tabGroups.query({ windowId: currentWindow.id });
     const groupList = document.getElementById('groupList');
+    
+    // スクロール位置を保存
+    const scrollTop = groupList.scrollTop;
+    
+    // 既存の内容をクリア
     groupList.innerHTML = '';
     
     if (groups.length === 0) {
@@ -66,6 +71,9 @@ async function updateGroupList() {
       
       groupList.appendChild(groupElement);
     }
+    
+    // スクロール位置を復元
+    groupList.scrollTop = scrollTop;
   } catch (error) {
     console.error('Error updating group list:', error);
     showStatus('エラーが発生しました');
@@ -176,6 +184,9 @@ async function updateExcludedDomainsList() {
       const excludedList = document.getElementById('excludedList');
       const excludedDomains = response.excludedDomains;
       
+      // スクロール位置を保存
+      const scrollTop = excludedList.scrollTop;
+      
       if (excludedDomains.length === 0) {
         excludedList.innerHTML = '<div class="empty-state">除外ドメインはありません</div>';
       } else {
@@ -191,6 +202,9 @@ async function updateExcludedDomainsList() {
           btn.addEventListener('click', () => removeExcludedDomain(btn.dataset.domain));
         });
       }
+      
+      // スクロール位置を復元
+      excludedList.scrollTop = scrollTop;
     }
   } catch (error) {
     console.error('Error updating excluded domains list:', error);
@@ -348,8 +362,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   });
   
-  // 定期的にグループリストを更新
-  setInterval(updateGroupList, 2000);
+  // 定期的にグループリストを更新（頻度を下げてUX改善）
+  setInterval(updateGroupList, 5000);
   
   // 初期ステータスを設定
   showStatus(settings.autoGroupEnabled ? '自動グループ化が有効です' : '自動グループ化が無効です');


### PR DESCRIPTION
## 問題
ポップアップウィンドウで定期的に一番上にスクロールされる問題が発生していました。これはユーザー体験として良くない状態でした。

## 原因
- `setInterval(updateGroupList, 2000)`で2秒おきにグループリストのHTMLを完全に再構築
- DOM要素の再生成によりスクロール位置がリセットされる

## 修正内容

### スクロール位置の保持
- **グループリスト更新**: `updateGroupList()`でスクロール位置を保存・復元
- **除外ドメインリスト更新**: `updateExcludedDomainsList()`でスクロール位置を保存・復元

### UX改善
- **更新頻度の調整**: 定期更新を2秒間隔から5秒間隔に変更
- **スムーズな操作**: スクロール中の急な位置リセットを防止

## 修正箇所
```javascript
// スクロール位置を保存
const scrollTop = groupList.scrollTop;

// DOM更新処理...

// スクロール位置を復元  
groupList.scrollTop = scrollTop;
```

## テスト確認項目
- [x] グループリストでスクロール位置が保持される
- [x] 除外ドメインリストでスクロール位置が保持される
- [x] 定期更新時にスクロールがリセットされない
- [x] 手動操作（ボタンクリック等）は正常に動作

これによりユーザーがスクロールした位置が保持され、より快適な操作体験を提供します。

🤖 Generated with [Claude Code](https://claude.ai/code)