### PR TITLE
favicon色抽出によるタブグループ色の自動設定機能を追加

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,0 +1,87 @@
+// Content script for favicon color extraction
+// Service WorkerではImage/Canvasが使用できないため、content scriptで色抽出を行う
+
+// faviconから主要色を抽出する関数
+function extractDominantColorFromFavicon(faviconUrl) {
+  return new Promise((resolve) => {
+    if (!faviconUrl || faviconUrl.startsWith('chrome://') || faviconUrl.startsWith('chrome-extension://')) {
+      resolve(null);
+      return;
+    }
+
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    
+    img.onload = () => {
+      try {
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d');
+        
+        // faviconを32x32にリサイズして描画
+        canvas.width = 32;
+        canvas.height = 32;
+        ctx.drawImage(img, 0, 0, 32, 32);
+        
+        // 画像データを取得
+        const imageData = ctx.getImageData(0, 0, 32, 32);
+        const data = imageData.data;
+        
+        // 色のヒストグラムを作成
+        const colorCounts = {};
+        for (let i = 0; i < data.length; i += 4) {
+          const r = data[i];
+          const g = data[i + 1];
+          const b = data[i + 2];
+          const a = data[i + 3];
+          
+          // 透明ピクセルと白に近い色はスキップ
+          if (a < 128 || (r > 240 && g > 240 && b > 240)) continue;
+          
+          // 色を簡略化（8段階に量子化）
+          const quantizedR = Math.floor(r / 32) * 32;
+          const quantizedG = Math.floor(g / 32) * 32;
+          const quantizedB = Math.floor(b / 32) * 32;
+          
+          const colorKey = `${quantizedR},${quantizedG},${quantizedB}`;
+          colorCounts[colorKey] = (colorCounts[colorKey] || 0) + 1;
+        }
+        
+        // 最も多く使われている色を取得
+        let dominantColor = null;
+        let maxCount = 0;
+        
+        for (const [colorKey, count] of Object.entries(colorCounts)) {
+          if (count > maxCount) {
+            maxCount = count;
+            const [r, g, b] = colorKey.split(',').map(Number);
+            dominantColor = { r, g, b };
+          }
+        }
+        
+        resolve(dominantColor);
+      } catch (error) {
+        console.error('Error extracting color from favicon:', error);
+        resolve(null);
+      }
+    };
+    
+    img.onerror = () => resolve(null);
+    img.src = faviconUrl;
+  });
+}
+
+// background scriptからのメッセージをリッスン
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === 'extractFaviconColor') {
+    extractDominantColorFromFavicon(message.faviconUrl)
+      .then(color => {
+        sendResponse({ success: true, color: color });
+      })
+      .catch(error => {
+        console.error('Error in favicon color extraction:', error);
+        sendResponse({ success: false, error: error.message });
+      });
+    
+    return true; // 非同期レスポンスを示す
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -12,6 +12,13 @@
   "background": {
     "service_worker": "background.js"
   },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ],
   "action": {
     "default_popup": "popup.html",
     "default_title": "Domain Tab Grouper"


### PR DESCRIPTION
## 概要
faviconから主要色を抽出してタブグループの色を自動設定する新機能を追加しました。これにより、各サイトの視覚的アイデンティティに合わせたタブグループ色が自動適用されます。

## 新機能
### 🎨 Favicon色抽出
- **Canvas API解析**: faviconから主要色を自動抽出
- **スマートマッピング**: Chrome拡張のグループカラーに最適変換
- **色キャッシュ**: ドメインごとの色情報を保存して高速化
- **フォールバック**: favicon取得失敗時のハッシュベース色生成

### 🔧 技術実装
- **Service Worker対応**: content scriptを使用してDOM制限を回避
- **色の量子化**: RGB値の8段階量子化でノイズ除去
- **距離計算**: ユークリッド距離でグループカラーマッピング
- **エラーハンドリング**: CORS、透明ピクセル、白色背景の適切な処理

## 変更内容
### ファイル追加
- **content.js**: favicon色抽出用content script
  - Image/Canvas APIを使用した色解析
  - background scriptとのメッセージング
  - 透明・白色ピクセルの除外処理

### ファイル変更
- **manifest.json**: content_scripts設定追加
  - 全URLでcontent script実行
  - document_idle時の読み込み設定

- **background.js**: 色抽出ロジック実装
  - `extractDominantColorFromFavicon()`: content scriptとの通信
  - `mapColorToGroupColor()`: RGB→グループカラー変換
  - `getGroupColor()`: favicon URL + tabID対応
  - ドメイン色キャッシュ機能

## 対応グループカラー
 < /dev/null |  色 | 対象サイト例 |
|---|---|
| 🔴 Red | YouTube、Google+ |
| 🩷 Pink | Instagram、Dribbble |
| 🟣 Purple | Twitch、Yahoo! |
| 🔵 Blue | Facebook、Twitter、LinkedIn |
| 🩵 Cyan | Skype |
| 🟢 Green | WhatsApp、Spotify |
| 🟡 Yellow | StackOverflow |
| ⚪ Grey | その他 |

## 影響範囲
- [x] Chrome拡張機能の動作
- [x] UI/UX（視覚的向上）
- [ ] パフォーマンス（色キャッシュで最適化）
- [ ] 既存機能への影響

## テスト
- [x] 基本的な動作確認
- [x] 新機能の動作確認
- [x] Service Workerエラー修正確認
- [x] 既存機能の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)