### PR TITLE
[chore] REPOSITORY_SETUP.mdを.gitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .claude/
 CLAUDE.md
 
+# Repository setup documentation
+.github/REPOSITORY_SETUP.md
+
 # OS generated files
 .DS_Store
 .DS_Store?


### PR DESCRIPTION
## Summary
リポジトリ設定完了後にREPOSITORY_SETUP.mdファイルを.gitignoreに追加

## Changes
- `.gitignore`にREPOSITORY_SETUP.mdを追加
- リポジトリ設定ガイドをバージョン管理から除外

🤖 Generated with [Claude Code](https://claude.ai/code)