### PR TITLE
[docs] READMEからChrome Extensionバッジリンクを削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Domain Tab Grouper 🗂️
 
-[![Chrome Extension](https://img.shields.io/badge/Chrome-Extension-blue.svg)](https://developer.chrome.com/docs/extensions/)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-green.svg)](https://developer.chrome.com/docs/extensions/mv3/intro/)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 


### PR DESCRIPTION
## Summary
READMEからChrome Extensionバッジとそのリンクを削除

## Changes
- Chrome Extensionバッジを削除
- よりクリーンなREADMEレイアウトに改善

🤖 Generated with [Claude Code](https://claude.ai/code)