### PR TITLE
v0.1.0ベース安定版 + グループ名変更・サブドメイン機能追加

### DIFF
--- a/content.js
+++ b/content.js
@@ -9,8 +9,11 @@ const CONFIG = {
 
 // faviconから主要色を抽出する関数
 function extractDominantColorFromFavicon(faviconUrl) {
+  console.log(`[Content Script] Extracting color from favicon: ${faviconUrl}`);
+  
   return new Promise((resolve) => {
     if (!faviconUrl || faviconUrl.startsWith('chrome://') || faviconUrl.startsWith('chrome-extension://')) {
+      console.log(`[Content Script] Invalid favicon URL: ${faviconUrl}`);
       resolve(null);
       return;
     }
@@ -66,6 +69,7 @@ function extractDominantColorFromFavicon(faviconUrl) {
           }
         }
         
+        console.log(`[Content Script] Extracted dominant color:`, dominantColor, `from ${Object.keys(colorCounts).length} colors`);
         resolve(dominantColor);
       } catch (error) {
         console.error('Error extracting color from favicon:', error);
@@ -73,20 +77,27 @@ function extractDominantColorFromFavicon(faviconUrl) {
       }
     };
     
-    img.onerror = () => resolve(null);
+    img.onerror = () => {
+      console.log(`[Content Script] Failed to load favicon: ${faviconUrl}`);
+      resolve(null);
+    };
+    
     img.src = faviconUrl;
   });
 }
 
 // background scriptからのメッセージをリッスン
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  console.log(`[Content Script] Received message:`, message);
+  
   if (message.action === 'extractFaviconColor') {
     extractDominantColorFromFavicon(message.faviconUrl)
       .then(color => {
+        console.log(`[Content Script] Sending response:`, { success: true, color });
         sendResponse({ success: true, color: color });
       })
       .catch(error => {
-        console.error('Error in favicon color extraction:', error);
+        console.error('[Content Script] Error in favicon color extraction:', error);
         sendResponse({ success: false, error: error.message });
       });
     

--- a/content.js
+++ b/content.js
@@ -1,7 +1,11 @@
 // Content script for favicon color extraction
 // Service WorkerではImage/Canvasが使用できないため、content scriptで色抽出を行う
 
-import { CONFIG } from './constants.js';
+// 設定定数（constants.jsから複製）
+const CONFIG = {
+  FAVICON_CANVAS_SIZE: 32,
+  COLOR_QUANTIZATION_LEVEL: 32
+};
 
 // faviconから主要色を抽出する関数
 function extractDominantColorFromFavicon(faviconUrl) {

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": ["https://*/*", "http://*/*"],
       "js": ["content.js"],
       "run_at": "document_idle"
     }

--- a/manifest.json
+++ b/manifest.json
@@ -17,8 +17,7 @@
     {
       "matches": ["<all_urls>"],
       "js": ["content.js"],
-      "run_at": "document_idle",
-      "type": "module"
+      "run_at": "document_idle"
     }
   ],
   "action": {

--- a/popup.html
+++ b/popup.html
@@ -140,6 +140,13 @@
       color: #333;
     }
     
+    .toggle-description {
+      font-size: 11px;
+      color: #5f6368;
+      margin-top: 4px;
+      line-height: 1.3;
+    }
+    
     .excluded-domains-section {
       margin-top: 20px;
       padding: 15px;
@@ -394,6 +401,90 @@
       text-align: center;
     }
 
+    /* ドメイン名設定のスタイル */
+    .domain-names-section {
+      margin-top: 20px;
+      padding: 15px;
+      background-color: #f0f7ff;
+      border-radius: 8px;
+      border: 1px solid #c8e6c9;
+    }
+
+    .name-input-container {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 12px;
+      align-items: center;
+    }
+
+    .name-list {
+      max-height: 120px;
+      overflow-y: auto;
+    }
+
+    .name-item {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 8px 10px;
+      margin-bottom: 4px;
+      background-color: white;
+      border-radius: 4px;
+      border: 1px solid #c8e6c9;
+      font-size: 12px;
+    }
+
+    .name-domain {
+      flex: 1;
+      color: #333;
+      font-family: monospace;
+      word-break: break-all;
+      margin-right: 8px;
+    }
+
+    .name-display {
+      padding: 4px 8px;
+      border-radius: 12px;
+      font-size: 11px;
+      font-weight: 500;
+      background-color: #e8f5e8;
+      color: #2e7d32;
+      margin-right: 8px;
+    }
+
+    .quick-name {
+      margin-top: 8px;
+    }
+
+    .context-menu-item.rename {
+      color: #2e7d32;
+    }
+
+    .context-menu-item.rename:hover {
+      background-color: #e8f5e8;
+    }
+
+    /* グループ名入力メニューのスタイル */
+    .group-name-input-menu {
+      position: absolute;
+      background: white;
+      border: 1px solid #dadce0;
+      border-radius: 12px;
+      box-shadow: 0 6px 16px rgba(0,0,0,0.2);
+      z-index: 1001;
+      min-width: 280px;
+      display: none;
+      padding: 16px;
+    }
+
+    .name-input-header {
+      font-size: 14px;
+      font-weight: 600;
+      color: #333;
+      margin-bottom: 12px;
+      text-align: center;
+    }
+
   </style>
 </head>
 <body>
@@ -408,6 +499,17 @@
         <span class="toggle-slider"></span>
         <span class="toggle-text">自動グループ化</span>
       </label>
+    </div>
+    <div class="toggle-container">
+      <label class="toggle-label">
+        <input type="checkbox" id="subdomainGroupingToggle" class="toggle-checkbox">
+        <span class="toggle-slider"></span>
+        <span class="toggle-text">サブドメイン単位グループ化</span>
+      </label>
+      <div class="toggle-description">
+        有効: mail.google.com と drive.google.com を別グループ<br>
+        無効: すべて google.com として同一グループ
+      </div>
     </div>
     <button id="groupTabs" class="btn">手動でグループ化</button>
     <button id="ungroupAll" class="btn secondary">すべてのグループを解除</button>
@@ -426,6 +528,21 @@
     </div>
     <div class="excluded-list" id="excludedList">
       <div class="empty-state">除外ドメインはありません</div>
+    </div>
+  </div>
+
+  <div class="domain-names-section">
+    <div class="section-title">ドメイン名設定</div>
+    <div class="name-input-container">
+      <input type="text" id="nameDomainInput" class="domain-input" placeholder="example.com">
+      <input type="text" id="nameInput" class="domain-input" placeholder="カスタムグループ名">
+      <button id="addNameBtn" class="btn small">設定</button>
+    </div>
+    <div class="quick-name">
+      <button id="setCurrentNameBtn" class="btn small secondary">現在のタブのグループ名を設定</button>
+    </div>
+    <div class="name-list" id="nameList">
+      <div class="empty-state">ドメイン名設定はありません</div>
     </div>
   </div>
 
@@ -458,13 +575,27 @@
 
   <!-- コンテキストメニュー -->
   <div class="context-menu" id="contextMenu">
-    <div class="context-menu-item exclude" id="excludeDomainMenu">
-      <span class="context-menu-icon">🚫</span>
-      <span>除外ドメインに追加</span>
+    <div class="context-menu-item rename" id="renameGroupMenu">
+      <span class="context-menu-icon">✏️</span>
+      <span>グループ名を変更</span>
     </div>
     <div class="context-menu-item color-change" id="changeColorMenu">
       <span class="context-menu-icon">🎨</span>
       <span>色を変更する</span>
+    </div>
+    <div class="context-menu-item exclude" id="excludeDomainMenu">
+      <span class="context-menu-icon">🚫</span>
+      <span>除外ドメインに追加</span>
+    </div>
+  </div>
+
+  <!-- グループ名入力メニュー -->
+  <div class="group-name-input-menu" id="groupNameInputMenu">
+    <div class="name-input-header">グループ名を変更</div>
+    <div class="name-input-container">
+      <input type="text" id="groupNameInput" class="domain-input" placeholder="新しいグループ名を入力">
+      <button id="applyGroupNameBtn" class="btn small">適用</button>
+      <button id="cancelGroupNameBtn" class="btn small secondary">キャンセル</button>
     </div>
   </div>
 

--- a/popup.js
+++ b/popup.js
@@ -22,15 +22,17 @@ async function saveSettings(settings) {
 // 設定を読み込む関数
 async function loadSettings() {
   try {
-    const result = await chrome.storage.local.get(['autoGroupEnabled', 'excludedDomains', 'domainColors']);
+    const result = await chrome.storage.local.get(['autoGroupEnabled', 'excludedDomains', 'domainColors', 'domainNames', 'useSubdomainGrouping']);
     return {
       autoGroupEnabled: result.autoGroupEnabled !== false, // デフォルトはtrue
       excludedDomains: result.excludedDomains || [], // デフォルトは空配列
-      domainColors: result.domainColors || {} // デフォルトは空オブジェクト
+      domainColors: result.domainColors || {}, // デフォルトは空オブジェクト
+      domainNames: result.domainNames || {}, // デフォルトは空オブジェクト
+      useSubdomainGrouping: result.useSubdomainGrouping || false // デフォルトはfalse
     };
   } catch (error) {
     console.error('Error loading settings:', error);
-    return { autoGroupEnabled: true, excludedDomains: [], domainColors: {} };
+    return { autoGroupEnabled: true, excludedDomains: [], domainColors: {}, domainNames: {}, useSubdomainGrouping: false };
   }
 }
 
@@ -195,6 +197,34 @@ async function toggleAutoGroup() {
   }
 }
 
+// サブドメイングループ化の設定を切り替える関数
+async function toggleSubdomainGrouping() {
+  try {
+    const toggle = document.getElementById('subdomainGroupingToggle');
+    const enabled = toggle.checked;
+    
+    // 設定を保存
+    await saveSettings({ useSubdomainGrouping: enabled });
+    
+    // バックグラウンドスクリプトに設定変更を通知
+    await chrome.runtime.sendMessage({ 
+      action: 'toggleSubdomainGrouping', 
+      enabled: enabled 
+    });
+    
+    // ステータス更新
+    showStatus(enabled ? 'サブドメイン単位グループ化が有効になりました' : 'ルートドメイン単位グループ化に戻しました');
+    
+    // グループリストを更新（グループ名が変わる可能性があるため）
+    setTimeout(() => {
+      updateGroupList();
+    }, 1000);
+  } catch (error) {
+    console.error('Error toggling subdomain grouping:', error);
+    showStatus('設定の更新に失敗しました');
+  }
+}
+
 // 除外ドメインリストを更新する関数
 async function updateExcludedDomainsList() {
   try {
@@ -307,6 +337,151 @@ async function excludeCurrentTabDomain() {
     await addExcludedDomain(domain);
   } catch (error) {
     console.error('Error excluding current tab domain:', error);
+    showStatus('エラーが発生しました');
+  }
+}
+
+// ドメイン名リストを更新する関数
+async function updateDomainNamesList() {
+  try {
+    const response = await chrome.runtime.sendMessage({ action: 'getDomainNames' });
+    if (response && response.success) {
+      const nameList = document.getElementById('nameList');
+      const domainNames = response.domainNames;
+      
+      // スクロール位置を保存
+      const scrollTop = nameList.scrollTop;
+      
+      if (Object.keys(domainNames).length === 0) {
+        nameList.innerHTML = '<div class="empty-state">ドメイン名設定はありません</div>';
+      } else {
+        nameList.innerHTML = Object.entries(domainNames).map(([domain, name]) => `
+          <div class="name-item">
+            <span class="name-domain">${domain}</span>
+            <span class="name-display">${name}</span>
+            <button class="remove-btn" data-domain="${domain}">削除</button>
+          </div>
+        `).join('');
+        
+        // 削除ボタンのイベントリスナーを追加
+        nameList.querySelectorAll('.remove-btn').forEach(btn => {
+          btn.addEventListener('click', () => removeDomainName(btn.dataset.domain));
+        });
+      }
+      
+      // スクロール位置を復元
+      nameList.scrollTop = scrollTop;
+    }
+  } catch (error) {
+    console.error('Error updating domain names list:', error);
+  }
+}
+
+// ドメイン名を設定する関数
+async function addDomainName(domain, name) {
+  try {
+    if (!domain || domain.trim() === '') {
+      showStatus('ドメインを入力してください');
+      return;
+    }
+    
+    if (!name || name.trim() === '') {
+      showStatus('グループ名を入力してください');
+      return;
+    }
+    
+    domain = domain.trim().toLowerCase();
+    name = name.trim();
+    
+    // 簡単なバリデーション
+    if (!isValidDomain(domain)) {
+      showStatus('無効なドメイン形式です');
+      return;
+    }
+    
+    showStatus('ドメイン名を設定中...');
+    
+    const response = await chrome.runtime.sendMessage({ 
+      action: 'setDomainName', 
+      domain: domain,
+      name: name
+    });
+    
+    if (response && response.success) {
+      showStatus(`${domain} のグループ名を "${name}" に設定しました`);
+      await updateDomainNamesList();
+      
+      // 入力フィールドをクリア（存在する場合のみ）
+      const domainInput = document.getElementById('nameDomainInput');
+      const nameInput = document.getElementById('nameInput');
+      if (domainInput) domainInput.value = '';
+      if (nameInput) nameInput.value = '';
+      
+      // グループリストも更新（名前が変わったため）
+      setTimeout(() => {
+        updateGroupList();
+      }, 500);
+    } else {
+      showStatus((response && response.error) || 'ドメイン名の設定に失敗しました');
+    }
+  } catch (error) {
+    console.error('Error setting domain name:', error);
+    showStatus('エラーが発生しました');
+  }
+}
+
+// ドメイン名を削除する関数
+async function removeDomainName(domain) {
+  try {
+    showStatus('ドメイン名設定を削除中...');
+    
+    const response = await chrome.runtime.sendMessage({ 
+      action: 'removeDomainName', 
+      domain: domain 
+    });
+    
+    if (response && response.success) {
+      showStatus(`${domain} のグループ名設定を削除しました`);
+      await updateDomainNamesList();
+      
+      // グループリストも更新（名前が変わったため）
+      setTimeout(() => {
+        updateGroupList();
+      }, 500);
+    } else {
+      showStatus((response && response.error) || 'ドメイン名設定の削除に失敗しました');
+    }
+  } catch (error) {
+    console.error('Error removing domain name:', error);
+    showStatus('エラーが発生しました');
+  }
+}
+
+// 現在のタブのドメイン名を設定する関数
+async function setCurrentTabName() {
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (!tab || !tab.url) {
+      showStatus('現在のタブのドメインを取得できません');
+      return;
+    }
+    
+    const domain = extractDomain(tab.url);
+    if (!domain) {
+      showStatus('このタブはグループ化対象外です');
+      return;
+    }
+    
+    const nameInput = document.getElementById('nameInput');
+    if (!nameInput.value) {
+      showStatus('グループ名を入力してください');
+      return;
+    }
+    
+    document.getElementById('nameDomainInput').value = domain;
+    await addDomainName(domain, nameInput.value);
+  } catch (error) {
+    console.error('Error setting current tab name:', error);
     showStatus('エラーが発生しました');
   }
 }
@@ -595,6 +770,24 @@ async function excludeDomainFromMenu() {
   }
 }
 
+// グループ名変更（コンテキストメニューから）
+async function renameGroupFromMenu() {
+  if (!currentContextDomain) {
+    showStatus('ドメインが選択されていません');
+    return;
+  }
+  
+  // currentContextDomainを保持するため、先にドメインを保存
+  const domainToProcess = currentContextDomain;
+  
+  hideContextMenu();
+  
+  // ドメインを復元
+  currentContextDomain = domainToProcess;
+  
+  showGroupNameInputMenu();
+}
+
 // 色変更（コンテキストメニューから）
 async function changeColorFromMenu() {
   
@@ -681,6 +874,73 @@ function cancelGroupColor() {
   currentContextDomain = null;
 }
 
+// グループ名入力メニューを表示
+function showGroupNameInputMenu() {
+  const nameMenu = document.getElementById('groupNameInputMenu');
+  
+  // メニューの位置を計算（画面中央に表示）
+  const popupRect = document.body.getBoundingClientRect();
+  nameMenu.style.left = Math.max(10, (popupRect.width - 280) / 2) + 'px';
+  nameMenu.style.top = '150px';
+  nameMenu.style.display = 'block';
+  
+  // 入力フィールドをリセット
+  const groupNameInput = document.getElementById('groupNameInput');
+  groupNameInput.value = '';
+  groupNameInput.focus();
+  
+  // クリック外し処理を有効化
+  setTimeout(() => {
+    document.addEventListener('click', handleGroupNameMenuClickOutside);
+  }, 100);
+}
+
+// グループ名入力メニューを非表示
+function hideGroupNameInputMenu() {
+  const nameMenu = document.getElementById('groupNameInputMenu');
+  nameMenu.style.display = 'none';
+  document.removeEventListener('click', handleGroupNameMenuClickOutside);
+}
+
+// グループ名入力メニュー外をクリックしたときの処理
+function handleGroupNameMenuClickOutside(event) {
+  const nameMenu = document.getElementById('groupNameInputMenu');
+  if (!nameMenu.contains(event.target)) {
+    hideGroupNameInputMenu();
+  }
+}
+
+// グループ名を適用する処理
+async function applyGroupName() {
+  const groupNameInput = document.getElementById('groupNameInput');
+  const newName = groupNameInput.value.trim();
+  
+  if (!currentContextDomain) {
+    showStatus('ドメインが選択されていません');
+    return;
+  }
+  
+  if (!newName) {
+    showStatus('グループ名を入力してください');
+    return;
+  }
+  
+  hideGroupNameInputMenu();
+  
+  // addDomainName関数と同じロジックを使用
+  await addDomainName(currentContextDomain, newName);
+  
+  // 適用後にcurrentContextDomainをリセット
+  currentContextDomain = null;
+}
+
+// グループ名入力をキャンセルする処理
+function cancelGroupName() {
+  hideGroupNameInputMenu();
+  // キャンセル時にcurrentContextDomainをリセット
+  currentContextDomain = null;
+}
+
 
 
 // ドメインからホスト名を抽出する関数
@@ -723,12 +983,15 @@ document.addEventListener('DOMContentLoaded', async () => {
   // 設定を読み込んでトグルスイッチを初期化
   const settings = await loadSettings();
   const toggle = document.getElementById('autoGroupToggle');
+  const subdomainToggle = document.getElementById('subdomainGroupingToggle');
   toggle.checked = settings.autoGroupEnabled;
+  subdomainToggle.checked = settings.useSubdomainGrouping;
   
-  // 初期化時にグループリストと除外ドメインリスト、ドメイン色リストを更新
+  // 初期化時にグループリストと除外ドメインリスト、ドメイン色リスト、ドメイン名リストを更新
   updateGroupList();
   updateExcludedDomainsList();
   updateDomainColorsList();
+  updateDomainNamesList();
   
   // ボタンのイベントリスナー
   document.getElementById('groupTabs').addEventListener('click', groupTabs);
@@ -736,6 +999,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   
   // トグルスイッチのイベントリスナー
   toggle.addEventListener('change', toggleAutoGroup);
+  subdomainToggle.addEventListener('change', toggleSubdomainGrouping);
   
   // 除外ドメイン関連のイベントリスナー
   document.getElementById('addDomainBtn').addEventListener('click', () => {
@@ -750,6 +1014,32 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (e.key === 'Enter') {
       const domain = document.getElementById('domainInput').value;
       addExcludedDomain(domain);
+    }
+  });
+
+  // ドメイン名関連のイベントリスナー
+  document.getElementById('addNameBtn').addEventListener('click', () => {
+    const domain = document.getElementById('nameDomainInput').value;
+    const name = document.getElementById('nameInput').value;
+    addDomainName(domain, name);
+  });
+  
+  document.getElementById('setCurrentNameBtn').addEventListener('click', setCurrentTabName);
+  
+  // Enterキーでドメイン名設定
+  document.getElementById('nameDomainInput').addEventListener('keypress', (e) => {
+    if (e.key === 'Enter') {
+      const domain = document.getElementById('nameDomainInput').value;
+      const name = document.getElementById('nameInput').value;
+      addDomainName(domain, name);
+    }
+  });
+  
+  document.getElementById('nameInput').addEventListener('keypress', (e) => {
+    if (e.key === 'Enter') {
+      const domain = document.getElementById('nameDomainInput').value;
+      const name = document.getElementById('nameInput').value;
+      addDomainName(domain, name);
     }
   });
 
@@ -774,10 +1064,22 @@ document.addEventListener('DOMContentLoaded', async () => {
   // コンテキストメニューのイベントリスナー
   document.getElementById('excludeDomainMenu').addEventListener('click', excludeDomainFromMenu);
   document.getElementById('changeColorMenu').addEventListener('click', changeColorFromMenu);
+  document.getElementById('renameGroupMenu').addEventListener('click', renameGroupFromMenu);
 
   // グループ色選択メニューのイベントリスナー
   document.getElementById('applyGroupColorBtn').addEventListener('click', applyGroupColor);
   document.getElementById('cancelGroupColorBtn').addEventListener('click', cancelGroupColor);
+  
+  // グループ名入力メニューのイベントリスナー
+  document.getElementById('applyGroupNameBtn').addEventListener('click', applyGroupName);
+  document.getElementById('cancelGroupNameBtn').addEventListener('click', cancelGroupName);
+  
+  // グループ名入力でEnterキー
+  document.getElementById('groupNameInput').addEventListener('keypress', (e) => {
+    if (e.key === 'Enter') {
+      applyGroupName();
+    }
+  });
   
   // グループ変更を監視してリアルタイム更新
   let currentGroupState = null;

--- a/popup.js
+++ b/popup.js
@@ -1,8 +1,5 @@
 // ポップアップUIの制御スクリプト
 
-// インポート（Chrome拡張のESモジュールサポートはManifest V3で利用可能）
-import { COLOR_CODES } from './constants.js';
-
 // ドメインからホスト名を抽出する関数
 function extractDomain(url) {
   try {
@@ -103,7 +100,17 @@ async function updateGroupList() {
 
 // グループ色をカラーコードに変換
 function getColorCode(color) {
-  return COLOR_CODES[color] || COLOR_CODES.blue;
+  const colorMap = {
+    grey: '#9aa0a6',
+    blue: '#4285f4',
+    red: '#ea4335',
+    yellow: '#fbbc04',
+    green: '#34a853',
+    pink: '#ff8bcb',
+    purple: '#9c27b0',
+    cyan: '#00bcd4'
+  };
+  return colorMap[color] || '#4285f4';
 }
 
 


### PR DESCRIPTION
## Summary
- v0.1.0の安定したグループ化ロジックを基盤として復活
- v0.4.0のグループ名変更機能を再実装
- サブドメイン単位グループ化オプションを新規追加
- favicon色抽出機能のデバッグ・フォールバック改善

## 主な変更点

### 🔧 グループ化ロジックの安定化
- v0.1.0の確実に動作するextractDomain関数を復活
- extractDomainWithExclusion関数を削除してシンプル化
- 除外ドメインチェックを各箇所で明示的に実行

### ✏️ グループ名変更機能
- v0.4.0で提供していたグループ名カスタマイズ機能を再実装
- コンテキストメニューからの直感的な名前変更
- ドメイン名設定セクションでの一括管理
- 既存グループのタイトル自動更新

### 🌐 サブドメイン単位グループ化
- 新機能：mail.google.com と drive.google.com を別グループにするオプション
- デフォルトはルートドメイン単位（従来通り）
- ポップアップで簡単に切り替え可能
- 設定変更時に既存グループも自動再構築

### 🎨 favicon色抽出の改善
- デバッグログの追加で問題特定を容易化
- フォールバック色選択ロジックの改善（青一色問題を解決）
- faviconURL再取得機能の追加
- ハッシュベース色分散の改善

## Test plan
- [x] v0.1.0同様の確実なグループ化動作
- [x] グループ名変更機能の動作確認
- [x] サブドメイン/ルートドメイン切り替えの動作確認
- [x] favicon色抽出とフォールバック色の確認
- [x] 既存機能への影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)